### PR TITLE
force->inumeric corrected to utils::inumeric

### DIFF
--- a/compute_rdf_ext.cpp
+++ b/compute_rdf_ext.cpp
@@ -54,11 +54,11 @@ ComputeRDFExtend::ComputeRDFExtend(LAMMPS *lmp, int narg, char **arg) :
   while (iarg < narg) {
     if (strcmp(arg[iarg],"Nbin") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal compute rdf/ext command");
-      binsize = force->inumeric(FLERR,arg[iarg+1]);
+      binsize = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       iarg += 2;
     } else if (strcmp(arg[iarg],"Nwrite") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal compute rdf/ext command");
-      WriteFileEvery = force->inumeric(FLERR,arg[iarg+1]);
+      WriteFileEvery = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       iarg += 2;
     } else if (strcmp(arg[iarg],"file") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix ordern command");

--- a/fix_ordern.cpp
+++ b/fix_ordern.cpp
@@ -107,9 +107,9 @@ FixOrderN::FixOrderN(LAMMPS *lmp, int narg, char **arg) :
   } else 
     error->all(FLERR,"Illegal fix ordern command");
   // rate of sampling (end_of_step())
-  nevery = force->inumeric(FLERR,arg[4]); 
+  nevery = utils::inumeric(FLERR,arg[4],false,lmp); 
   // rate of writing files
-  nfreq = force->inumeric(FLERR,arg[5]);  
+  nfreq = utils::inumeric(FLERR,arg[5],false,lmp);  
   global_freq = nevery;  
 
   // OBTAINING THE ID OF COMPUTE FOR THIS FIX
@@ -159,17 +159,17 @@ FixOrderN::FixOrderN(LAMMPS *lmp, int narg, char **arg) :
     } else if (strcmp(arg[iarg],"start") == 0) {
       if (iarg+2 > narg)
         error->all(FLERR,"Illegal fix ordern command");
-      startstep = force->inumeric(FLERR,arg[iarg+1]);
+      startstep = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       iarg += 2;
     } else if (strcmp(arg[iarg],"nb") == 0) {
       if (iarg+2 > narg)
         error->all(FLERR,"Illegal fix ordern command");
-      tnb = force->inumeric(FLERR,arg[iarg+1]);
+      tnb = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       iarg += 2;
     } else if (strcmp(arg[iarg],"nbe") == 0) {
       if (iarg+2 > narg)
         error->all(FLERR,"Illegal fix ordern command");
-      tnbe = force->inumeric(FLERR,arg[iarg+1]);
+      tnbe = utils::inumeric(FLERR,arg[iarg+1],false,lmp);
       iarg += 2;
     } else if (strcmp(arg[iarg],"format") == 0) {
       if (iarg+2 > narg) error->all(FLERR,"Illegal fix ordern command");


### PR DESCRIPTION
The stable branch of lammps now use utils::inumeric to convert strings to integers. 